### PR TITLE
Add menu state and construct game dispatcher from it

### DIFF
--- a/game-core/src/lib.rs
+++ b/game-core/src/lib.rs
@@ -8,8 +8,52 @@ extern crate rand;
 mod component;
 mod load;
 mod map;
-pub mod state;
-pub mod system;
+mod state;
+mod system;
+
+use amethyst::{
+    core::TransformBundle,
+    input::InputBundle,
+    prelude::*,
+    renderer::{
+        ColorMask, DepthMode, DisplayConfig, DrawSprite, Pipeline, RenderBundle, Stage, ALPHA,
+    },
+    utils::application_root_dir,
+};
+use state::Menu;
+
+pub fn run() -> amethyst::Result<()> {
+    let root = format!("{}/resources", application_root_dir());
+    let config = DisplayConfig::load(format!("{}/display_config.ron", root));
+    let pipe = Pipeline::build().with_stage(
+        Stage::with_backbuffer()
+            .clear_target([0.1, 0.1, 0.1, 1.0], 1.0)
+            .with_pass(DrawSprite::new().with_transparency(
+                ColorMask::all(),
+                ALPHA,
+                Some(DepthMode::LessEqualWrite), // Tells the pipeline to respect sprite z-depth
+            )),
+    );
+
+    let game_data = GameDataBuilder::default()
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(
+            InputBundle::<String, String>::new()
+                .with_bindings_from_file(format!("{}/input.ron", root))?,
+        )?.with(
+            amethyst::utils::ortho_camera::CameraOrthoSystem::default(),
+            "OrthoCamera",
+            &[],
+        ).with_bundle(
+            RenderBundle::new(pipe, Some(config))
+                .with_sprite_sheet_processor()
+                .with_sprite_visibility_sorting(&[]), // Let's us use the `Transparent` component
+        )?;
+
+    let mut game = Application::build(root, Menu)?.build(game_data)?;
+    game.run();
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {

--- a/game-core/src/state/game.rs
+++ b/game-core/src/state/game.rs
@@ -1,54 +1,14 @@
-use amethyst::prelude::*;
-use component::Player;
-use crate::load;
+use amethyst::{ecs::prelude::*, prelude::*};
 
-pub struct Game;
-
-impl<'a, 'b> SimpleState<'a, 'b> for Game {
-    fn on_start(&mut self, data: StateData<GameData>) {
-        let world = data.world;
-
-        world.add_resource(load::LoadedTextures::default());
-
-        let player_sprite_sheet_handle = load::sprite_sheet(world, "FRONT.png", "FRONT.ron");
-        let _penguin_sprite_sheet_handle =
-            load::sprite_sheet(world, "penguinFront.png", "penguinFront.ron");
-        let _ = load::sprite_sheet(world, "bubble.png", "bubble.ron");
-
-        crate::map::load_map_sprites(world);
-        let parent = Player::new(world, &player_sprite_sheet_handle);
-        init::camera(world, parent);
-    }
+pub struct Game<'a, 'b> {
+    pub dispatcher: Dispatcher<'a, 'b>,
 }
 
-mod init {
-    use amethyst::{
-        core::Transform,
-        ecs::Entity,
-        prelude::*,
-        renderer::Camera,
-        utils::ortho_camera::{CameraNormalizeMode, CameraOrtho},
-    };
+impl<'a, 'b> State<GameData<'a, 'b>, StateEvent> for Game<'a, 'b> {
+    fn update(&mut self, data: StateData<GameData<'a, 'b>>) -> Trans<GameData<'a, 'b>, StateEvent> {
+        data.data.update(&data.world);
+        self.dispatcher.dispatch(&data.world.res);
 
-    pub fn camera(world: &mut World, parent: Entity) {
-        let mut transform = {
-            let transforms = world.read_storage::<Transform>();
-            transforms.get(parent).unwrap().clone()
-        };
-
-        world.register::<CameraOrtho>();
-
-        transform.translation.z = 2.0;
-        transform.translation.x -= 256.0;
-        transform.translation.y -= 256.0;
-        transform.scale.x = 512.0;
-        transform.scale.y = 512.0;
-
-        world
-            .create_entity()
-            .with(CameraOrtho::normalized(CameraNormalizeMode::Contain))
-            .with(Camera::standard_2d())
-            .with(transform)
-            .build();
+        Trans::None
     }
 }

--- a/game-core/src/state/menu.rs
+++ b/game-core/src/state/menu.rs
@@ -37,7 +37,7 @@ impl SimpleState<'static, 'static> for Menu {
         data: &mut StateData<GameData>,
     ) -> Trans<GameData<'static, 'static>, StateEvent> {
         let world = &mut data.world;
-        let mut dispatcher: Dispatcher<'static, 'static> = DispatcherBuilder::new()
+        let mut dispatcher: Dispatcher = DispatcherBuilder::new()
             .with(player::Movement, "player-movement", &[])
             .with(enemy::Movement, "enemy-movement", &[])
             .with(camera::Movement, "camera-movement", &[])

--- a/game-core/src/state/menu.rs
+++ b/game-core/src/state/menu.rs
@@ -1,0 +1,77 @@
+use amethyst::{
+    core::Transform,
+    ecs::prelude::*,
+    ecs::Entity,
+    prelude::*,
+    renderer::Camera,
+    utils::ortho_camera::{CameraNormalizeMode, CameraOrtho},
+};
+use component::{Animation, Player};
+use crate::load;
+use crate::state::Game;
+use crate::system::*;
+
+pub struct Menu;
+
+impl SimpleState<'static, 'static> for Menu {
+    fn on_start(&mut self, data: StateData<GameData>) {
+        let world = data.world;
+
+        world.register::<Player>();
+        world.register::<Animation>();
+
+        world.add_resource(load::LoadedTextures::default());
+
+        let player_sprite_sheet_handle = load::sprite_sheet(world, "FRONT.png", "FRONT.ron");
+        let _penguin_sprite_sheet_handle =
+            load::sprite_sheet(world, "penguinFront.png", "penguinFront.ron");
+        let _ = load::sprite_sheet(world, "bubble.png", "bubble.ron");
+
+        crate::map::load_map_sprites(world);
+        let parent = Player::new(world, &player_sprite_sheet_handle);
+        init_camera(world, parent);
+    }
+
+    fn update(
+        &mut self,
+        data: &mut StateData<GameData>,
+    ) -> Trans<GameData<'static, 'static>, StateEvent> {
+        let world = &mut data.world;
+        let mut dispatcher: Dispatcher<'static, 'static> = DispatcherBuilder::new()
+            .with(player::Movement, "player-movement", &[])
+            .with(enemy::Movement, "enemy-movement", &[])
+            .with(camera::Movement, "camera-movement", &[])
+            .with(enemy::Spawner, "enemy-spawner", &[])
+            .with(ally::Movement, "ally-movement", &[])
+            .with(ally::Grouper, "ally-grouper", &[])
+            .with(ally::Spawner, "ally-spawner", &[])
+            .with(player::Attack, "player-attack", &[])
+            .with(animation::Frame, "frame-animation", &[])
+            .with(projectile::Movement, "projectile-movement", &[])
+            .build();
+        dispatcher.setup(&mut world.res);
+        Trans::Push(Box::new(Game { dispatcher }))
+    }
+}
+
+pub fn init_camera(world: &mut World, parent: Entity) {
+    let mut transform = {
+        let transforms = world.read_storage::<Transform>();
+        transforms.get(parent).unwrap().clone()
+    };
+
+    world.register::<CameraOrtho>();
+
+    transform.translation.z = 2.0;
+    transform.translation.x -= 256.0;
+    transform.translation.y -= 256.0;
+    transform.scale.x = 512.0;
+    transform.scale.y = 512.0;
+
+    world
+        .create_entity()
+        .with(CameraOrtho::normalized(CameraNormalizeMode::Contain))
+        .with(Camera::standard_2d())
+        .with(transform)
+        .build();
+}

--- a/game-core/src/state/mod.rs
+++ b/game-core/src/state/mod.rs
@@ -1,3 +1,5 @@
 mod game;
+mod menu;
 
 pub use self::game::Game;
+pub use self::menu::Menu;

--- a/game-main/src/main.rs
+++ b/game-main/src/main.rs
@@ -1,64 +1,13 @@
-extern crate amethyst;
 extern crate game_core;
 
-use amethyst::{
-    core::TransformBundle,
-    input::InputBundle,
-    prelude::*,
-    renderer::{
-        ColorMask, DepthMode, DisplayConfig, DrawSprite, Pipeline, RenderBundle, Stage, ALPHA,
-    },
-    utils::application_root_dir,
-};
-use game_core::state::Game;
-use game_core::system::{ally, animation, camera, enemy, player, projectile};
 use std::env;
 
-fn main() -> amethyst::Result<()> {
+fn main() {
     if let Err(env::VarError::NotPresent) = env::var("RUST_LOG") {
         env::set_var("RUST_LOG", "debug,gfx_device_gl=warn,amethyst_assets=warn");
     }
 
     env_logger::init();
 
-    let root = format!("{}/resources", application_root_dir());
-    let config = DisplayConfig::load(format!("{}/display_config.ron", root));
-    let pipe = Pipeline::build().with_stage(
-        Stage::with_backbuffer()
-            .clear_target([0.1, 0.1, 0.1, 1.0], 1.0)
-            .with_pass(DrawSprite::new().with_transparency(
-                ColorMask::all(),
-                ALPHA,
-                Some(DepthMode::LessEqualWrite), // Tells the pipeline to respect sprite z-depth
-            )),
-    );
-
-    let game_data = GameDataBuilder::default()
-        .with_bundle(TransformBundle::new())?
-        .with_bundle(
-            InputBundle::<String, String>::new()
-                .with_bindings_from_file(format!("{}/input.ron", root))?,
-        )?.with(player::Movement, "player-movement", &[])
-        .with(enemy::Movement, "enemy-movement", &[])
-        .with(camera::Movement, "camera-movement", &[])
-        .with(enemy::Spawner, "enemy-spawner", &[])
-        .with(ally::Movement, "ally-movement", &[])
-        .with(ally::Grouper, "ally-grouper", &[])
-        .with(ally::Spawner, "ally-spawner", &[])
-        .with(player::Attack, "player-attack", &[])
-        .with(animation::Frame, "frame-animation", &[])
-        .with(projectile::Movement, "projectile-movement", &[])
-        .with(
-            amethyst::utils::ortho_camera::CameraOrthoSystem::default(),
-            "OrthoCamera",
-            &[],
-        ).with_bundle(
-            RenderBundle::new(pipe, Some(config))
-                .with_sprite_sheet_processor()
-                .with_sprite_visibility_sorting(&[]), // Let's us use the `Transparent` component
-        )?;
-
-    let mut game = Application::build(root, Game)?.build(game_data)?;
-    game.run();
-    Ok(())
+    game_core::run().unwrap();
 }


### PR DESCRIPTION
This change adds a custom dispatcher to the game state, such that we can pause game logic when going into different states like pause and editor. It constructs the dispatcher for the game state in the menu loading state, which could eventually be reorganized to be in response to hitting start.

This will also pave the way towards adding the Player entity as a member of the various systems that are in the game state, for addressing #27.